### PR TITLE
Allow setting work tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,26 @@ var gitSpawnedStream = require('git-spawned-stream');
 var streamingParser = require('./lib/parser');
 
 function blame(repoPath, opts) {
-  var args = ['blame', (opts.rev || 'HEAD'), '-p', '--', opts.file];
+  var rev = typeof opts.rev !== 'undefined' ? opts.rev : 'HEAD';
+  var args = [];
 
-  if(opts.ignoreWhitespaces) {
-    args.splice(3, 0, '-w');
+  if (typeof opts.workTree === 'string') {
+    args.push('--work-tree=' + opts.workTree);
   }
+
+  args.push('blame');
+
+  if (rev) {
+    args.push(rev);
+  }
+
+  if (opts.ignoreWhitespaces) {
+    args.push('-w');
+  }
+
+  args.push('-p');
+  args.push('--');
+  args.push(opts.file);
 
   // TODO: implement limit
   return streamingParser(gitSpawnedStream(repoPath, args));


### PR DESCRIPTION
This will allow us to set the work tree where the `git blame` command should run. Without this it is not possible to blame rows changed but not yet staged or committed.

This should help in solving issues like [this](https://github.com/waderyan/vscode-gitblame/issues/19).