### PR TITLE
Adding options for -L, -C, and -M

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,39 @@ line { hash: '856f13ab053f6b5dfa58d6e6c726d43cc5e73d00',
 That's all, folks!
 ```
 
+## Options
+
+The options should be an `object`.
+
+### `rev` (`Boolean` or `String`)
+`<rev>` from `git blame`. If empty it will default to `HEAD`. If `false` and `workTree` is set it will use the work tree.
+
+### `workTree` (`String`)
+`--work-tree` from `git`. If empty no work tree will be used. Use full path.
+
+### `ignoreWhitespace` (`Boolean`)
+`-w` from `git blame`.
+
+### `limitLines` (`String`)
+`-L` from `git blame`.
+
+### `detectMoved` (`Boolean` or `Number`)
+`-M` from `git blame`. Requiered for `detectCopy`.
+
+### `detectCopy` (`Boolean` or `Number`)
+`-C` from `git blame`.
+
+### `detectCopyMode` (`String`)
+Possible options:
+* `any` - Look in all files and at all times
+* `created` - Look in files changed in the commit creating the file
+* `default` - Look in the same commit
+
+If left empty it will default to `default`.
+
+### `file` (`String`)
+`<file>` in `git blame`.
+
 ## Tests
 
 ```

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gitSpawnedStream = require('git-spawned-stream');
 var streamingParser = require('./lib/parser');
 
 function blame(repoPath, opts) {
-  var rev = typeof opts.rev !== 'undefined' ? opts.rev : 'HEAD';
+  var rev = typeof opts.rev !== 'undefined' ? opts.rev : 'HEAD';
   var args = [];
 
   if (typeof opts.workTree === 'string') {
@@ -19,6 +19,41 @@ function blame(repoPath, opts) {
 
   if (opts.ignoreWhitespaces) {
     args.push('-w');
+  }
+
+  if (opts.limitLines) {
+    args.push('-L ' + opts.limitLines);
+  }
+
+  if (opts.detectMoved) {
+    if (typeof opts.detectMoved === 'number') {
+      args.push('-M' + opts.detectMoved);
+    } else {
+      args.push('-M');
+    }
+  }
+
+  if (opts.detectCopy) {
+    switch (opts.detectCopyMode) {
+    case 'any':
+      args.push('-C -C');
+      break;
+
+    case 'created':
+      args.push('-C');
+      break;
+
+    case 'default':
+    default:
+      // Placeholder
+      break;
+    }
+
+    if (typeof opts.detectCopy === 'number') {
+      args.push('-C' + opts.detectCopy);
+    } else {
+      args.push('-C');
+    }
   }
 
   args.push('-p');


### PR DESCRIPTION
This PR will add options for the `-L`, `-C`, and `-M` flags of `git blame`. It will also add some basic documentation for the options in the `readme`.