### PR TITLE
[WIP] support `--contents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shelling out to [git blame](http://git-scm.com/docs/git-blame) in a streaming No
 ## Usage
 
 ```js
-gitBlame(repoPath, options)
+gitBlame(file, options)
 ```
 
 Example:
@@ -20,8 +20,8 @@ var repoPath = path.resolve(process.env.REPO || (__dirname + '/.git'));
 var file = process.env.FILE || 'package.json';
 var rev = process.env.REV || 'HEAD';
 
-gitBlame(repoPath, {
-  file: file,
+gitBlame(file, {
+  repoPath: repoPath,
   rev: rev
 }).on('data', function(type, data) {
   // type can be 'line' or 'commit'
@@ -168,43 +168,58 @@ line { hash: '856f13ab053f6b5dfa58d6e6c726d43cc5e73d00',
 That's all, folks!
 ```
 
+## Parameters:
+
+- `file`    - `String` - `<file>` in `git blame`
+- `options` - `Object` - optional options
+
 ## Options
 
-The options should be an `object`.
+The options should be an `object` extend from [git-spawned-stream](https://github.com/gucong3000/git-spawned-stream/tree/options.input#options)
 
-### `rev` (`Boolean` or `String`)
+### `rev` `{String}`
+
 `<rev>` from `git blame`. If empty it will default to `HEAD`. If `false` and `workTree` is set it will use the work tree.
 
-### `workTree` (`String`)
-`--work-tree` from `git`. If empty no work tree will be used. Use full path.
+### `ignoreWhitespace` `{boolean}`
 
-### `ignoreWhitespace` (`Boolean`)
+Default: `true`
+
 `-w` from `git blame`.
 
-### `limitLines` (`String`)
+### `limitLines` `{String}`
+
 `-L` from `git blame`.
 
-### `detectMoved` (`Boolean` or `Number`)
+### `contents` `{String}`
+
+`--contents <file>` from `git blame`
+
+### `input` `{String|Buffer|Stream.Readable}`
+
+`--contents -` from `git blame`
+
+### `detectMoved` `{boolean|number}`
+
+Default: `true`
+
 `-M` from `git blame`. Requiered for `detectCopy`.
 
-### `detectCopy` (`Boolean` or `Number`)
+### `detectCopy` `{boolean|number}`
+
+Default: `true`
+
 `-C` from `git blame`.
 
-### `detectCopyMode` (`String`)
+### `detectCopyMode` `{String}`
+
 Possible options:
-* `any` - Look in all files and at all times
-* `created` - Look in files changed in the commit creating the file
-* `default` - Look in the same commit
+
+- `any` - Look in all files and at all times
+- `created` - Look in files changed in the commit creating the file
+- `default` - Look in the same commit
 
 If left empty it will default to `default`.
-
-### `file` (`String`)
-`<file>` in `git blame`.
-
-## gitCommand
-
-This is an optional 3rd parameter besides the repo path and options.
-It's the path to the git binary to use (use the one in `PATH` by default).
 
 ## Tests
 

--- a/example.js
+++ b/example.js
@@ -6,10 +6,10 @@ var path = require('path');
 
 var repoPath = path.resolve(process.env.REPO || (__dirname + '/.git'));
 var file = process.env.FILE || 'package.json';
-var rev = process.env.REV || 'HEAD';
+var rev = process.env.REV;
 
-gitBlame(repoPath, {
-  file: file,
+gitBlame(file, {
+  repoPath: repoPath,
   rev: rev
 }).on('data', function(type, data) {
   // type can be 'line' or 'commit'

--- a/index.js
+++ b/index.js
@@ -3,18 +3,40 @@
 var gitSpawnedStream = require('git-spawned-stream');
 var streamingParser = require('./lib/parser');
 
-function blame(repoPath, opts, gitCommand = 'git') {
-  var rev = typeof opts.rev !== 'undefined' ? opts.rev : 'HEAD';
-  var args = [];
+/**
+ * Create a readable stream from a spawned git process.
+ * @param   {String}                         file                      `<file>` in `git blame`
+ * @param   {Object}                         [options]                 options extend from [git-spawned-stream](https://github.com/gucong3000/git-spawned-stream/tree/options.input#options)
+ * @param   {String}                         [rev]                     `<rev>` from `git blame`
+ * @param   {boolean}                        [ignoreWhitespace=true]   `-w` from `git blame`
+ * @param   {String}                         [limitLines]              `-L` from `git blame`
+ * @param   {String}                         [contents]                `--contents <file>` from `git blame`
+ * @param   {String|Buffer|Stream.Readable}  [input]                   `--contents -` from `git blame`
+ * @param   {boolean|number}                 [detectMoved=true]        `-M` from `git blame`. Requiered for `detectCopy`
+ * @param   {boolean|number}                 [detectCopy=true]         `-C` from `git blame`
+ * @param   {String}                         [detectCopyMode]          Possible options:
+- `any` - Look in all files and at all times
+- `created` - Look in files changed in the commit creating the file
+- `default` - Look in the same commit
+ * @returns {Stream.Readable}                                          readable stream from spawned git process.
+ */
+function blame(file, opts) {
+  opts = Object.assign({
+    ignoreWhitespaces: true,
+    detectMoved: true,
+    detectCopy: true,
+  }, opts)
 
-  if (typeof opts.workTree === 'string') {
-    args.push('--work-tree=' + opts.workTree);
-  }
+  var args = ['blame'];
 
-  args.push('blame');
-
-  if (rev) {
-    args.push(rev);
+  if (opts.rev) {
+    args.push(opts.rev);
+  } else if (opts.input) {
+    args.push('--contents');
+    args.push('-');
+  } else if (opts.contents) {
+    args.push('--contents');
+    args.push(opts.contents);
   }
 
   if (opts.ignoreWhitespaces) {
@@ -58,10 +80,9 @@ function blame(repoPath, opts, gitCommand = 'git') {
 
   args.push('-p');
   args.push('--');
-  args.push(opts.file);
+  args.push(file);
 
-  // TODO: implement limit
-  return streamingParser(gitSpawnedStream(repoPath, args, gitCommand));
+  return streamingParser(gitSpawnedStream(args, opts));
 }
 
 module.exports = blame;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Shelling out to git blame in a streaming Node fashion.",
   "main": "index.js",
   "dependencies": {
-    "git-spawned-stream": "1.0.0",
     "debug": "~2.2.0",
+    "git-spawned-stream": "github:gucong3000/git-spawned-stream#options.input",
     "split-transform-stream": "~1.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,12 @@ describe('git-blame', function() {
 
   it('should delegate with the correct params', function(done) {
     var repoPath = '/home/node.git';
-    var opts = { rev: 'master', file: 'CHANGES.md' };
+    var opts = {
+      ignoreWhitespaces: false,
+      detectMoved: false,
+      detectCopy: false,
+      repoPath: repoPath,
+    };
 
     var gitBlame = proxyquire.load('../', {
       './lib/parser': function(inputStream) {
@@ -34,15 +39,15 @@ describe('git-blame', function() {
 
         return 'streamingParser';
       },
-      'git-spawned-stream': function(path, args) {
-        path.should.eql(repoPath);
-        args.should.eql(['blame', opts.rev, '-p', '--', opts.file]);
+      'git-spawned-stream': function(args, configs) {
+        configs.repoPath.should.eql(repoPath);
+        args.should.eql(['blame', '-p', '--', 'CHANGES.md']);
 
         return 'git-spawned-stream';
       }
     });
 
-    gitBlame(repoPath, opts).should.eql('streamingParser');
+    gitBlame('CHANGES.md', opts).should.eql('streamingParser');
 
     done();
   });


### PR DESCRIPTION
- implement limit
- support [--contents](https://git-scm.com/docs/git-blame#git-blame---contentsltfilegt)
  -  working tree copy
  -  read from the standard input